### PR TITLE
vtk-9.0.3 b2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "9.0.3" %}
-{% set build_number = 1 %}
+{% set build_number = 2 %}
 
 {% set major_minor = ".".join(version.split(".")[:2]) %}
 
@@ -26,9 +26,10 @@ source:
     - no-explicit-task-scheduler.patch
     # tbb::atomic was deprecated and removed, replace it with std::atomic.
     - use-std-atomic-instead-of-tbb-atomic.patch
+    - patches/0001_add-missing-cpp-header-for-linux.patch
 
 build:
-  skip: True  # [win32 or s390x or ppc64le or py==310]
+  skip: True  # [win32 or s390x or ppc64le]
   number: {{ build_number }}
   features:
     - mesalib   # [VTK_WITH_OSMESA]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0001_add-missing-cpp-header-for-linux.patch
 
 build:
-  skip: True  # [win or s390x or ppc64le or py==310]
+  skip: True  # [win32 or s390x or ppc64le or py<37]
   number: {{ build_number }}
   features:
     - mesalib   # [VTK_WITH_OSMESA]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ build:
   ignore_run_exports:
     # Seems required to enable OGG support, but not actually linked to?
     - libogg
+    - qt  # [not win]
   run_exports:
     - {{ pin_subpackage('vtk', max_pin='x.x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -140,7 +140,6 @@ requirements:
     - gl2ps
     # Not all our Qt builds in distribution seem to export a pinning.
     - {{ pin_compatible('qt') }}  # [not win]
-    - qt-main
     - xz
 
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ build:
   ignore_run_exports:
     # Seems required to enable OGG support, but not actually linked to?
     - libogg
+    - qt
   run_exports:
     - {{ pin_subpackage('vtk', max_pin='x.x.x') }}
 
@@ -139,8 +140,8 @@ requirements:
     - sqlite
     - gl2ps
     # Not all our Qt builds in distribution seem to export a pinning.
-  #  - {{ pin_compatible('qt') }}  # [not win]
-  #  - qt-main
+    - {{ pin_compatible('qt') }}  # [not win]
+    - qt-main
     - xz
 
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0001_add-missing-cpp-header-for-linux.patch
 
 build:
-  skip: True  # [win or s390x or ppc64le or py<310]
+  skip: True  # [win or s390x or ppc64le or py==310]
   number: {{ build_number }}
   features:
     - mesalib   # [VTK_WITH_OSMESA]
@@ -140,7 +140,7 @@ requirements:
     - gl2ps
     # Not all our Qt builds in distribution seem to export a pinning.
   #  - {{ pin_compatible('qt') }}  # [not win]
-    - qt-main
+  #  - qt-main
     - xz
 
   run_constrained:
@@ -149,7 +149,6 @@ requirements:
 
 test:
   imports:
-    - vtk
     - vtk.vtkChartsCore
     - vtk.vtkCommonCore
     - vtk.vtkFiltersCore

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,6 @@ build:
   ignore_run_exports:
     # Seems required to enable OGG support, but not actually linked to?
     - libogg
-    - qt
   run_exports:
     - {{ pin_subpackage('vtk', max_pin='x.x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,7 +43,7 @@ build:
   ignore_run_exports:
     # Seems required to enable OGG support, but not actually linked to?
     - libogg
-    - qt  # [not win]
+    - qt-main
   run_exports:
     - {{ pin_subpackage('vtk', max_pin='x.x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0001_add-missing-cpp-header-for-linux.patch
 
 build:
-  skip: True  # [win32 or s390x or ppc64le or py<310]
+  skip: True  # [win or s390x or ppc64le or py<310]
   number: {{ build_number }}
   features:
     - mesalib   # [VTK_WITH_OSMESA]
@@ -190,13 +190,14 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: Copyright.txt
-  summary: >
+  summary: |
+    Process images and create 3D computer graphics with the Visualization Toolkit.
+  description: |
     The Visualization Toolkit (VTK) is an open-source, freely available software
     system for 3D computer graphics, modeling, image processing, volume
     rendering, scientific visualization, and information visualization.
   dev_url: https://gitlab.kitware.com/vtk/vtk
-  doc_url: https://www.vtk.org/files/release/{{major_minor}}/vtkDocHtml-{{version}}.tar.gz
-  doc_source_url: https://github.com/Kitware/VTK/tree/v{{version}}/Documentation/Doxygen
+  doc_url: https://vtk.org/about/#citation
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
     - patches/0001_add-missing-cpp-header-for-linux.patch
 
 build:
-  skip: True  # [win32 or s390x or ppc64le]
+  skip: True  # [win32 or s390x or ppc64le or py<310]
   number: {{ build_number }}
   features:
     - mesalib   # [VTK_WITH_OSMESA]
@@ -140,7 +140,8 @@ requirements:
     - sqlite
     - gl2ps
     # Not all our Qt builds in distribution seem to export a pinning.
-    - qt =5  # [not win]
+    - {{ pin_compatible('qt') }}  # [not win]
+    - qt-main
     - xz
 
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
   version: {{ version }}
 
 source:
-  url: http://www.vtk.org/files/release/{{ major_minor }}/VTK-{{ version }}.tar.gz
+  url: https://www.vtk.org/files/release/{{ major_minor }}/VTK-{{ version }}.tar.gz
   fn:  VTK-{{ version }}.tar.gz
   sha256: bc3eb9625b2b8dbfecb6052a2ab091fc91405de4333b0ec68f3323815154ed8a
   patches:
@@ -43,7 +43,6 @@ build:
   ignore_run_exports:
     # Seems required to enable OGG support, but not actually linked to?
     - libogg
-    - qt-main
   run_exports:
     - {{ pin_subpackage('vtk', max_pin='x.x.x') }}
 
@@ -140,7 +139,7 @@ requirements:
     - sqlite
     - gl2ps
     # Not all our Qt builds in distribution seem to export a pinning.
-    - {{ pin_compatible('qt') }}  # [not win]
+  #  - {{ pin_compatible('qt') }}  # [not win]
     - qt-main
     - xz
 
@@ -186,7 +185,7 @@ test:
     - python
 
 about:
-  home: https://www.vtk.org/
+  home: https://vtk.org/
   license: BSD-3-Clause
   license_family: BSD
   license_file: Copyright.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -140,7 +140,7 @@ requirements:
     - sqlite
     - gl2ps
     # Not all our Qt builds in distribution seem to export a pinning.
-    - {{ pin_compatible('qt') }}  # [not win]
+    - qt =5  # [not win]
     - xz
 
   run_constrained:

--- a/recipe/patches/0001_add-missing-cpp-header-for-linux.patch
+++ b/recipe/patches/0001_add-missing-cpp-header-for-linux.patch
@@ -1,0 +1,48 @@
+diff --git a/Common/Core/vtkGenericDataArrayLookupHelper.h b/Common/Core/vtkGenericDataArrayLookupHelper.h
+index ab9d57248f8eb0689dd2d389f69cf74873168c65..202aaa27f4ae9a1b3a6eecfec101b81b59f8fdcf 100644
+--- a/Common/Core/vtkGenericDataArrayLookupHelper.h
++++ b/Common/Core/vtkGenericDataArrayLookupHelper.h
+@@ -25,6 +25,7 @@
+ #include "vtkIdList.h"
+ #include <algorithm>
+ #include <cmath>
++#include <limits>
+ #include <unordered_map>
+ #include <vector>
+ 
+diff --git a/Common/DataModel/vtkPiecewiseFunction.cxx b/Common/DataModel/vtkPiecewiseFunction.cxx
+index 22eca0bc22e17189b37d48e483a0062d90ac035d..11086f1dc421b720d19c72326850c4f04d54cf57 100644
+--- a/Common/DataModel/vtkPiecewiseFunction.cxx
++++ b/Common/DataModel/vtkPiecewiseFunction.cxx
+@@ -22,6 +22,7 @@
+ #include <cassert>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 
+diff --git a/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx b/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+index a16bb27fc66850f8fd832bbb8f01c36c8a58bbd2..1052192c61635eb7a215ec66648a5fd88dd9fc6a 100644
+--- a/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
++++ b/Filters/HyperTree/vtkHyperTreeGridThreshold.cxx
+@@ -27,6 +27,7 @@
+ #include "vtkHyperTreeGridNonOrientedCursor.h"
+ 
+ #include <cmath>
++#include <limits>
+ 
+ vtkStandardNewMacro(vtkHyperTreeGridThreshold);
+ 
+diff --git a/Rendering/Core/vtkColorTransferFunction.cxx b/Rendering/Core/vtkColorTransferFunction.cxx
+index 55c046b4df76129611d0f6c65cdafdedb8b5b11c..1be02919ab9043472f819d8a3ff3ef68ade78e18 100644
+--- a/Rendering/Core/vtkColorTransferFunction.cxx
++++ b/Rendering/Core/vtkColorTransferFunction.cxx
+@@ -21,6 +21,7 @@
+ #include <algorithm>
+ #include <cmath>
+ #include <iterator>
++#include <limits>
+ #include <set>
+ #include <vector>
+ 


### PR DESCRIPTION
### Overview:
`vtk` needs to be built on py310 for [`mayavi`](https://anaconda.atlassian.net/browse/PKG-527)
Jira: https://anaconda.atlassian.net/browse/PKG-1018
Upstream: https://gitlab.kitware.com/vtk/vtk/-/tree/master

**Changes:**

1. Bumped build number from 1 to 2
2. Removed py310 skip
3. Added upstream [patch](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/7611?commit_id=e066c3f4fbbfe7470c6207db0fc3f3952db633cb)