### PR TITLE
vtk 9.4.1: Rebuild with libtiff 4.7.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -9,3 +9,4 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
   - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853
+  - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c

--- a/abs.yaml
+++ b/abs.yaml
@@ -7,4 +7,4 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,13 +5,3 @@ build_parameters:
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
-  - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853
-  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137
-  - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c
-  - https://staging.continuum.io/prefect/fs/leptonica-feedstock/pr5/6551fda
-  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/53e70a8
-  - https://staging.continuum.io/prefect/fs/gdk-pixbuf-feedstock/pr6/ffce0d6
-  - https://staging.continuum.io/prefect/fs/pillow-feedstock/pr31/90bf181

--- a/abs.yaml
+++ b/abs.yaml
@@ -13,3 +13,4 @@ channels:
   - https://staging.continuum.io/prefect/fs/leptonica-feedstock/pr5/6551fda
   - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/53e70a8
   - https://staging.continuum.io/prefect/fs/gdk-pixbuf-feedstock/pr6/ffce0d6
+  - https://staging.continuum.io/prefect/fs/pillow-feedstock/pr31/90bf181

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,6 @@ build_parameters:
 
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/9f246b8

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,6 +9,7 @@ build_env_vars:
 channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
   - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853
+  - https://staging.continuum.io/prefect/fs/lcms2-feedstock/pr2/6d62137
   - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c
   - https://staging.continuum.io/prefect/fs/leptonica-feedstock/pr5/6551fda
   - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/53e70a8

--- a/abs.yaml
+++ b/abs.yaml
@@ -10,3 +10,6 @@ channels:
   - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
   - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853
   - https://staging.continuum.io/prefect/fs/openjpeg-feedstock/pr6/34fbf3c
+  - https://staging.continuum.io/prefect/fs/leptonica-feedstock/pr5/6551fda
+  - https://staging.continuum.io/prefect/fs/libwebp-feedstock/pr9/53e70a8
+  - https://staging.continuum.io/prefect/fs/gdk-pixbuf-feedstock/pr6/ffce0d6

--- a/abs.yaml
+++ b/abs.yaml
@@ -7,4 +7,5 @@ build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313: yes
 
 channels:
-  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/e3ccbbe
+  - https://staging.continuum.io/prefect/fs/libtiff-feedstock/pr21/34f8d4b
+  - https://staging.continuum.io/prefect/fs/proj.4-feedstock/pr9/7ccb853

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,7 +78,7 @@ requirements:
     - libxml2 {{ libxml2 }}
     - libpng {{ libpng }}
     - jpeg {{ jpeg }}
-    - libtiff 4.7.0
+    - libtiff {{ libtiff }}
     - jsoncpp 1.9.4
     - expat {{ expat }}
     # Limit TBB version. The oneAPI (2021.*) release removed the `tbb_stddef.h`
@@ -178,7 +178,7 @@ outputs:
         - libxml2 {{ libxml2 }}
         - libpng {{ libpng }}
         - jpeg {{ jpeg }}
-        - libtiff 4.7.0
+        - libtiff {{ libtiff }}
         - jsoncpp 1.9.4
         - expat {{ expat }}
         # Limit TBB version. The oneAPI (2021.*) release removed the `tbb_stddef.h`

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "9.4.1" %}
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}
 
@@ -78,7 +78,7 @@ requirements:
     - libxml2 {{ libxml2 }}
     - libpng {{ libpng }}
     - jpeg {{ jpeg }}
-    - libtiff {{ libtiff }}
+    - libtiff 4.7.0
     - jsoncpp 1.9.4
     - expat {{ expat }}
     # Limit TBB version. The oneAPI (2021.*) release removed the `tbb_stddef.h`
@@ -178,7 +178,7 @@ outputs:
         - libxml2 {{ libxml2 }}
         - libpng {{ libpng }}
         - jpeg {{ jpeg }}
-        - libtiff {{ libtiff }}
+        - libtiff 4.7.0
         - jsoncpp 1.9.4
         - expat {{ expat }}
         # Limit TBB version. The oneAPI (2021.*) release removed the `tbb_stddef.h`


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7600](https://anaconda.atlassian.net/browse/PKG-7600) 
- [Upstream repository](https://gitlab.kitware.com/vtk/vtk/-/tree/v9.4.1?ref_type=tags)

### Explanation of changes:

- Bump the build number to 1
- Pin libtiff in host

### Notes:

-

[PKG-7600]: https://anaconda.atlassian.net/browse/PKG-7600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ