### PR TITLE
vtk 9.4.1: rebuild against the latest sqlite

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "9.4.1" %}
-{% set build = 2 %}
+{% set build = 3 %}
 {% set qt_version = "6" %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira]() 
- [Upstream repository]()

### Explanation of changes:

- Bump the build number

### Notes:

- Rebuilding because of this `SONAME` change in `sqlite` https://github.com/AnacondaRecipes/sqlite-feedstock/pull/29/files#diff-d7075654874cb08007a21aaab3ecd4b3453a9087e7505d034d548b8938b599bcR21-R37