### PR TITLE
vtk 9.4.1 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "9.4.1" %}
-{% set build = 4 %}
 {% set qt_version = "6" %}
 
 {% set minor_version = ".".join(version.split(".")[:2]) %}
@@ -21,7 +20,7 @@ source:
     - patches/11929_disable_class_overrides_pyi.patch
 
 build:
-  number: {{ build }}
+  number: 5
   # qtbase isn't available for osx-64
   skip: True  # [osx and x86_64]
 
@@ -120,7 +119,7 @@ outputs:
         - libnetcdf {{ libnetcdf }}
         - libogg {{ libogg }}
         - libpng {{ libpng }}
-        - libtheora {{ libtheora }}
+        - libtheora 1.2.0
         - libtiff {{ libtiff }}
         - libxml2 {{ libxml2 }}
         - lz4-c {{ lz4_c }}


### PR DESCRIPTION
vtk 9.4.1 rebuild

defaults

### Links 

- [PKG-9580](https://anaconda.atlassian.net/browse/PKG-9580)

### Explanation of changes:

- rebuild against libtheora 1.2.0


[PKG-9580]: https://anaconda.atlassian.net/browse/PKG-9580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ