### PR TITLE
vtk 9.6.2 - rebuild due to jsoncpp 1.9.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - patches/9987_try_except_python_import.patch  # [not win]
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
jsoncpp changed from 1.9.6 -> 1.9.7
https://github.com/AnacondaRecipes/aggregate/blob/master/conda_build_config.yaml#L399

```
vtk-base 9.6.2 py314hca94626_0
------------------------------
file name   : vtk-base-9.6.2-py314hca94626_0.conda
name        : vtk-base
version     : 9.6.2
build       : py314hca94626_0
build number: 0
size        : 45.4 MB
license     : BSD-3-Clause
subdir      : osx-arm64
url         : https://repo.anaconda.com/pkgs/main/osx-arm64/vtk-base-9.6.2-py314hca94626_0.conda
md5         : 916511f0bc6df2808832093a17cc6e68
timestamp   : 2026-06-15 08:00:11 UTC
constraints : 
  - paraview ==9999999999
dependencies: 
  - double-conversion >=3.1.5,<4.0a0
  - fmt >=12.1.0,<13.0a0
  - freetype >=2.14.1,<3.0a0
  - hdf5 >=2.0.0,<2.0.1.0a0
  - jsoncpp >=1.9.6,<1.9.7.0a0
  - libboost >=1.88.0,<1.89.0a0
  - libcxx >=20
  - libexpat >=2.8.1,<3.0a0
  - libjpeg-turbo >=3.1.3,<4.0a0
  - libnetcdf >=4.10.0,<5.0a0
  - libogg >=1.3.5,<1.4.0a0
  - libpng >=1.6.56,<1.7.0a0
  - libtheora >=1.2.0,<1.3.0a0
  - libtiff >=4.7.1,<5.0a0
  - libxml2 >=2.14.6,<2.15.0a0
  - libzlib >=1.3.2,<2.0a0
  - lz4-c >=1.9.4,<1.10.0a0
  - matplotlib-base >=2.0.0
  - nlohmann_json
  - numpy
  - proj >=9.7.1,<9.7.2.0a0
  - python >=3.14,<3.15.0a0
  - python_abi 3.14.* *_cp314
  - qtbase >=6.11.0,<6.12.0a0
  - sqlite >=3.53.2,<4.0a0
  - tbb >=2021.8.0
  - utfcpp
  - xz >=5.8.2,<6.0a0
  ```