### PR TITLE
Rebuild against libxml2 2.15.3

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,3 +6,5 @@ cxx_compiler:  # [win]
 # 1.9.7 version is incompatible so we stay on 1.9.6 for now
 jsoncpp:
   - 1.9.6
+libxml2:
+  - 2.15.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
     - patches/9987_try_except_python_import.patch  # [not win]
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
vtk 9.6.2

**Destination channel:** defaults

### Links

- [PKG-15913](https://anaconda.atlassian.net/browse/PKG-15913) 
- [Upstream repository](https://gitlab.kitware.com/vtk/vtk)

### Explanation of changes:
- Rebuild against libxml2

[PKG-15913]: https://anaconda.atlassian.net/browse/PKG-15913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ